### PR TITLE
Fix: Java agent: update ref count in enabledLoggers

### DIFF
--- a/liblttng-ust-java-agent/java/org/lttng/ust/agent/LogFrameworkSkeleton.java
+++ b/liblttng-ust-java-agent/java/org/lttng/ust/agent/LogFrameworkSkeleton.java
@@ -67,6 +67,7 @@ public abstract class LogFrameworkSkeleton implements LogFramework {
 		Integer refcount = enabledLoggers.get(name);
 		refcount--;
 		assert (refcount >= 0);
+		enabledLoggers.put(name, refcount);
 
 		if (refcount == 0) {
 			/* Event is not used anymore, remove it from the map */


### PR DESCRIPTION
`Integer` objects [are immutable](http://stackoverflow.com/a/5124214/610505) in Java, so

    Integer refcount = enabledLoggers.get(name);
    refcount--;

does not update the value in `enabledLoggers`.