### PR TITLE
Add ctf_sequence_hex() macro

### DIFF
--- a/include/lttng/ust-tracepoint-event-nowrite.h
+++ b/include/lttng/ust-tracepoint-event-nowrite.h
@@ -39,12 +39,17 @@
 #undef ctf_sequence_nowrite
 #define ctf_sequence_nowrite(_type, _item, _src, _length_type, _src_length) \
 	_ctf_sequence_encoded(_type, _item, _src,		\
-			_length_type, _src_length, none, 1)
+			_length_type, _src_length, none, 1, 10)
+
+#undef ctf_sequence_nowrite_hex
+#define ctf_sequence_nowrite_hex(_type, _item, _src, _length_type, _src_length) \
+	_ctf_sequence_encoded(_type, _item, _src,		\
+			_length_type, _src_length, none, 1, 16)
 
 #undef ctf_sequence_text_nowrite
 #define ctf_sequence_text_nowrite(_type, _item, _src, _length_type, _src_length) \
 	_ctf_sequence_encoded(_type, _item, _src,		\
-			_length_type, _src_length, UTF8, 1)
+			_length_type, _src_length, UTF8, 1, 10)
 
 #undef ctf_string_nowrite
 #define ctf_string_nowrite(_item, _src)				\

--- a/include/lttng/ust-tracepoint-event-reset.h
+++ b/include/lttng/ust-tracepoint-event-reset.h
@@ -56,7 +56,7 @@
 
 #undef _ctf_sequence_encoded
 #define _ctf_sequence_encoded(_type, _item, _src, _length_type, \
-			_src_length, _encoding, _nowrite)
+			_src_length, _encoding, _nowrite, _elem_type_base)
 
 #undef _ctf_string
 #define _ctf_string(_item, _src, _nowrite)

--- a/include/lttng/ust-tracepoint-event-write.h
+++ b/include/lttng/ust-tracepoint-event-write.h
@@ -51,12 +51,17 @@
 #undef ctf_sequence
 #define ctf_sequence(_type, _item, _src, _length_type, _src_length) \
 	_ctf_sequence_encoded(_type, _item, _src,		\
-			_length_type, _src_length, none, 0)
+			_length_type, _src_length, none, 0, 10)
+
+#undef ctf_sequence_hex
+#define ctf_sequence_hex(_type, _item, _src, _length_type, _src_length) \
+	_ctf_sequence_encoded(_type, _item, _src,		\
+			_length_type, _src_length, none, 0, 16)
 
 #undef ctf_sequence_text
 #define ctf_sequence_text(_type, _item, _src, _length_type, _src_length) \
 	_ctf_sequence_encoded(_type, _item, _src,		\
-			_length_type, _src_length, UTF8, 0)
+			_length_type, _src_length, UTF8, 0, 10)
 
 #undef ctf_string
 #define ctf_string(_item, _src)					\

--- a/include/lttng/ust-tracepoint-event.h
+++ b/include/lttng/ust-tracepoint-event.h
@@ -165,8 +165,9 @@ static const char							\
 	},
 
 #undef _ctf_sequence_encoded
-#define _ctf_sequence_encoded(_type, _item, _src,	\
-			_length_type, _src_length, _encoding, _nowrite)	\
+#define _ctf_sequence_encoded(_type, _item, _src,		\
+			_length_type, _src_length, _encoding, _nowrite, \
+			_elem_type_base)			\
 	{							\
 	  .name = #_item,					\
 	  .type =						\
@@ -177,7 +178,7 @@ static const char							\
 			  .sequence =				\
 				{				\
 				  .length_type = __type_integer(_length_type, BYTE_ORDER, 10, none), \
-				  .elem_type = __type_integer(_type, BYTE_ORDER, 10, _encoding), \
+				  .elem_type = __type_integer(_type, BYTE_ORDER, _elem_type_base, _encoding), \
 				},				\
 			},					\
 		},						\
@@ -254,8 +255,8 @@ static void __event_probe__##_provider##___##_name(_TP_ARGS_DATA_PROTO(_args));
 	__event_len += sizeof(_type) * (_length);
 
 #undef _ctf_sequence_encoded
-#define _ctf_sequence_encoded(_type, _item, _src, _length_type,	\
-			_src_length, _encoding, _nowrite)	\
+#define _ctf_sequence_encoded(_type, _item, _src, _length_type,			 \
+			_src_length, _encoding, _nowrite, _elem_type_base)	 \
 	__event_len += lib_ring_buffer_align(__event_len, lttng_alignof(_length_type));   \
 	__event_len += sizeof(_length_type);				       \
 	__event_len += lib_ring_buffer_align(__event_len, lttng_alignof(_type)); \
@@ -391,7 +392,7 @@ size_t __event_get_size__##_provider##___##_name(size_t *__dynamic_len, _TP_ARGS
 
 #undef _ctf_sequence_encoded
 #define _ctf_sequence_encoded(_type, _item, _src, _length_type,		       \
-			_src_length, _encoding, _nowrite)		       \
+			_src_length, _encoding, _nowrite, _elem_type_base)     \
 	{								       \
 		unsigned long __ctf_tmp_ulong = (unsigned long) (_src_length); \
 		const void *__ctf_tmp_ptr = (_src);			       \
@@ -451,8 +452,8 @@ void __event_prepare_filter_stack__##_provider##___##_name(char *__stack_data,\
 	__event_align = _tp_max_t(size_t, __event_align, lttng_alignof(_type));
 
 #undef _ctf_sequence_encoded
-#define _ctf_sequence_encoded(_type, _item, _src, _length_type,	\
-			_src_length, _encoding, _nowrite)	\
+#define _ctf_sequence_encoded(_type, _item, _src, _length_type,		       \
+			_src_length, _encoding, _nowrite, _elem_type_base)     \
 	__event_align = _tp_max_t(size_t, __event_align, lttng_alignof(_length_type));	  \
 	__event_align = _tp_max_t(size_t, __event_align, lttng_alignof(_type));
 
@@ -514,7 +515,7 @@ size_t __event_get_align__##_provider##___##_name(_TP_ARGS_PROTO(_args))      \
 
 #undef _ctf_sequence_encoded
 #define _ctf_sequence_encoded(_type, _item, _src, _length_type,		\
-			_src_length, _encoding, _nowrite)		\
+			_src_length, _encoding, _nowrite, _elem_type_base) \
 	{								\
 		_length_type __tmpl = __stackvar.__dynamic_len[__dynamic_len_idx]; \
 		lib_ring_buffer_align_ctx(&__ctx, lttng_alignof(_length_type));\


### PR DESCRIPTION
This patch adds the `_elem_type_base` parameter to
the internal _ctf_sequence_encoded() macro to
specify the sequence's element type's base.

ctf_sequence_hex() sets the `_elem_type_base`
parameter to 16.

This is convenient for recording byte buffers and
viewing them in hexadecimal.

Suggested-by: Antoine Busque <abusque@efficios.com>
Signed-off-by: Philippe Proulx <eeppeliteloop@gmail.com>