### PR TITLE
RFC: Add ctf_string_maybe_null() field macro

### DIFF
--- a/include/Makefile.am
+++ b/include/Makefile.am
@@ -25,7 +25,8 @@ nobase_include_HEADERS = \
 	lttng/lttng-ust-tracelog.h \
 	lttng/ust-clock.h \
 	lttng/ust-getcpu.h \
-	lttng/ust-elf.h
+	lttng/ust-elf.h \
+	lttng/ust-string-utils.h
 
 # note: usterr-signal-safe.h, core.h and share.h need namespace cleanup.
 

--- a/include/lttng/ust-string-utils.h
+++ b/include/lttng/ust-string-utils.h
@@ -1,0 +1,28 @@
+#ifndef _LTTNG_UST_STRING_UTILS
+#define _LTTNG_UST_STRING_UTILS
+
+/*
+ * Copyright (c) 2011 - Mathieu Desnoyers <mathieu.desnoyers@efficios.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#define __LTTNG_UST_STRING_MAYBE_NULL(_str)	((_str) ? (_str) : "(null)")
+
+#endif /* _LTTNG_UST_STRING_UTILS */

--- a/include/lttng/ust-tracepoint-event-nowrite.h
+++ b/include/lttng/ust-tracepoint-event-nowrite.h
@@ -20,6 +20,8 @@
  * SOFTWARE.
  */
 
+#include <lttng/ust-string-utils.h>
+
 #undef ctf_integer_nowrite
 #define ctf_integer_nowrite(_type, _item, _src)			\
 	_ctf_integer_ext(_type, _item, _src, BYTE_ORDER, 10, 1)
@@ -54,6 +56,10 @@
 #undef ctf_string_nowrite
 #define ctf_string_nowrite(_item, _src)				\
 	_ctf_string(_item, _src, 1)
+
+#undef ctf_string_maybe_null_nowrite
+#define ctf_string_maybe_null_nowrite(_item, _src)			\
+	_ctf_string(_item, __LTTNG_UST_STRING_MAYBE_NULL(_src), 1)
 
 #undef ctf_enum_nowrite
 #define ctf_enum_nowrite(_provider, _name, _type, _item, _src)		\

--- a/include/lttng/ust-tracepoint-event-reset.h
+++ b/include/lttng/ust-tracepoint-event-reset.h
@@ -98,6 +98,9 @@
 #undef ctf_string
 #define ctf_string(_item, _src)
 
+#undef ctf_string_maybe_null
+#define ctf_string_maybe_null(_item, _src)
+
 #undef ctf_enum
 #define ctf_enum(_provider, _name, _type, _item, _src)
 
@@ -122,6 +125,9 @@
 
 #undef ctf_string_nowrite
 #define ctf_string_nowrite(_item, _src)
+
+#undef ctf_string_maybe_null_nowrite
+#define ctf_string_maybe_null_nowrite(_item, _src)
 
 #undef ctf_enum_nowrite
 #define ctf_enum_nowrite(_provider, _name, _type, _item, _src)

--- a/include/lttng/ust-tracepoint-event-write.h
+++ b/include/lttng/ust-tracepoint-event-write.h
@@ -20,6 +20,8 @@
  * SOFTWARE.
  */
 
+#include <lttng/ust-string-utils.h>
+
 #undef ctf_integer
 #define ctf_integer(_type, _item, _src)				\
 	_ctf_integer_ext(_type, _item, _src, BYTE_ORDER, 10, 0)
@@ -66,6 +68,10 @@
 #undef ctf_string
 #define ctf_string(_item, _src)					\
 	_ctf_string(_item, _src, 0)
+
+#undef ctf_string_maybe_null
+#define ctf_string_maybe_null(_item, _src)				\
+	_ctf_string(_item, __LTTNG_UST_STRING_MAYBE_NULL(_src), 0)
 
 #undef ctf_enum
 #define ctf_enum(_provider, _name, _type, _item, _src)			\


### PR DESCRIPTION
This one has the same signature as ctf_string(), but it will
write "(null)", like printf() does with a NULL %s, instead of
crashing because ctf_string() calls strlen() on its argument.

This is implemented as a different macro because otherwise, using
ctf_string(), you would not know if the argument is NULL or if
the argument was really "(null)". By using ctf_string_maybe_null(),
your code indicates that you know that the string might be NULL.

Signed-off-by: Philippe Proulx <eeppeliteloop@gmail.com>