### PR TITLE
Make code and man pages share the same default values

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -424,6 +424,15 @@ and installing the man pages.
 AM_CONDITIONAL([MAN_PAGES_OPT], [test "x$man_pages_opt" != "xno"])
 AM_CONDITIONAL([HAVE_ASCIIDOC_XMLTO], [test "x$have_asciidoc_xmlto" = "xyes"])
 
+# Default values
+AC_DEFUN([_AC_DEFINE_AND_SUBST], [
+	AC_DEFINE_UNQUOTED([CONFIG_$1], [$2], [$1])
+	$1="$2"
+	AC_SUBST([$1])
+])
+
+_AC_DEFINE_AND_SUBST([LTTNG_UST_DEFAULT_CONSTRUCTOR_TIMEOUT_MS], [3000])
+
 AC_CONFIG_FILES([
 	Makefile
 	doc/Makefile

--- a/doc/man/Makefile.am
+++ b/doc/man/Makefile.am
@@ -55,7 +55,8 @@ if MAN_PAGES_OPT
 if HAVE_ASCIIDOC_XMLTO
 # Tools to execute:
 ADOC = $(ASCIIDOC) -f $(ASCIIDOC_CONF) -d manpage \
-	-a lttng_version="$(PACKAGE_VERSION)"
+	-a lttng_version="$(PACKAGE_VERSION)" \
+	-a lttng_ust_register_timeout="@LTTNG_UST_DEFAULT_CONSTRUCTOR_TIMEOUT_MS@"
 ADOC_DOCBOOK = $(ADOC) -b docbook
 XTO = $(XMLTO) -m $(firstword $(XSL_SRC_FILES)) man
 

--- a/doc/man/lttng-ust.3.txt
+++ b/doc/man/lttng-ust.3.txt
@@ -1100,7 +1100,7 @@ The value 0 means _do not wait_. The value -1 means _wait forever_.
 Setting this environment variable to 0 is recommended for applications
 with time constraints on the process startup time.
 +
-Default: 3000.
+Default: {lttng_ust_register_timeout}.
 
 `LTTNG_UST_WITHOUT_BADDR_STATEDUMP`::
     Prevent `liblttng-ust` from performing a base address state dump

--- a/include/ust-comm.h
+++ b/include/ust-comm.h
@@ -40,7 +40,7 @@
  * variable "LTTNG_UST_REGISTER_TIMEOUT". Note that if the sessiond is not
  * found, the application proceeds directly without any delay.
  */
-#define LTTNG_UST_DEFAULT_CONSTRUCTOR_TIMEOUT_MS	3000
+#define LTTNG_UST_DEFAULT_CONSTRUCTOR_TIMEOUT_MS	CONFIG_LTTNG_UST_DEFAULT_CONSTRUCTOR_TIMEOUT_MS
 
 #define LTTNG_DEFAULT_RUNDIR				LTTNG_SYSTEM_RUNDIR
 #define LTTNG_DEFAULT_HOME_RUNDIR			".lttng"


### PR DESCRIPTION
This is so that the code and the man pages are always synced.

Future default values should use the same mechanism.