### PR TITLE
doc: Add flags for JUL and python agent compiling

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,16 +225,18 @@ This package contains the following elements:
     It _has_ to be preloaded in order to hijack calls. In contrast,
     `liblttng-ust` may be linked at build time.
   - `liblttng-ust-java`: a simple library that uses JNI to allow tracing
-    in Java programs.
+    in Java programs. (Configure with `--enable-jni-interface`).
   - `liblttng-ust-java-agent`: a package that includes a JNI library and a
     JAR library to provide an LTTng-UST logging back-end for Java
-    applications using Java Util Logging or Log4j.
+    applications using Java Util Logging or Log4j. (Configure with
+    `--enable-java-agent-jul` or `--enable-java-agent-log4j` or
+    `--enable-java-agent-all`).
   - `liblttng-ust-libc-wrapper`: an example library that can be
     preloaded to instrument some calls to libc (currently `malloc()` and
     `free()`) and to POSIX threads (mutexes currently instrumented) in
     any program without need to recompile it.
   - `liblttng-ust-python-agent`: a library used by python-lttngust to allow
-    tracing in Python applications.
+    tracing in Python applications. (Configure with `--enable-python-agent`)
   - `libringbuffer`: the ring buffer implementation used within LTTng-UST.
   - `python-lttngust`: a package to provide an LTTng-UST logging back-end
     for Python applications using the standard logging framework.

--- a/configure.ac
+++ b/configure.ac
@@ -512,16 +512,16 @@ AS_ECHO(["LTTng-UST will be built with the following options:"])
 AS_ECHO
 
 AS_ECHO_N(["Java agent (JUL support): "])
-AS_IF([test "x$java_agent_jul" = "xyes"], [AS_ECHO(["Enabled"])], [AS_ECHO(["Disabled"])])
+AS_IF([test "x$java_agent_jul" = "xyes"], [AS_ECHO(["Enabled"])], [AS_ECHO(["Disabled (Use --enable-java-agent-jul)"])])
 
 AS_ECHO_N(["Java agent (Log4j support): "])
-AS_IF([test "x$java_agent_log4j" = "xyes"], [AS_ECHO(["Enabled"])], [AS_ECHO(["Disabled"])])
+AS_IF([test "x$java_agent_log4j" = "xyes"], [AS_ECHO(["Enabled"])], [AS_ECHO(["Disabled (Use --enable-java-agent-log4j)"])])
 
 AS_ECHO_N(["JNI interface (JNI): "])
-AS_IF([test "x$jni_interface" = "xyes"], [AS_ECHO(["Enabled"])], [AS_ECHO(["Disabled"])])
+AS_IF([test "x$jni_interface" = "xyes"], [AS_ECHO(["Enabled"])], [AS_ECHO(["Disabled (Use --enable-jni-interface)"])])
 
 AS_ECHO_N(["Python ($PYTHON) agent: "])
-AS_IF([test "x$python_agent" = "xyes"], [AS_ECHO(["Enabled"])], [AS_ECHO(["Disabled"])])
+AS_IF([test "x$python_agent" = "xyes"], [AS_ECHO(["Enabled"])], [AS_ECHO(["Disabled (Use --enable-python-agent)"])])
 
 AS_ECHO_N(["sdt.h integration: "])
 AS_IF([test "x$with_sdt" = "xyes"], [AS_ECHO(["Enabled"])], [AS_ECHO(["Disabled"])])


### PR DESCRIPTION
The compilation flag documentation is added to the README.md and
configure.ac files for easier access to them.

Signed-off-by: Geneviève Bastien <gbastien+lttng@versatic.net>