### PR TITLE
RFC: Add true globbing support

### DIFF
--- a/config/ax_check_posix_regcomp.m4
+++ b/config/ax_check_posix_regcomp.m4
@@ -1,0 +1,46 @@
+# ===========================================================================
+#  http://www.gnu.org/software/autoconf-archive/ax_check_posix_regcomp.html
+# ===========================================================================
+#
+# SYNOPSIS
+#
+#   AX_CHECK_POSIX_REGCOMP
+#
+# DESCRIPTION
+#
+#   Check that the POSIX compliant regular expression compiler is available
+#   in the POSIX specified manner, and it works. If it fails, we have a
+#   backup -- use gnu-regex.
+#
+# LICENSE
+#
+#   Copyright (c) 2008 Bruce Korb <bkorb@gnu.org>
+#
+#   Copying and distribution of this file, with or without modification, are
+#   permitted in any medium without royalty provided the copyright notice
+#   and this notice are preserved. This file is offered as-is, without any
+#   warranty.
+
+#serial 5
+
+AU_ALIAS([AG_CHECK_POSIX_REGCOMP], [AX_CHECK_POSIX_REGCOMP])
+AC_DEFUN([AX_CHECK_POSIX_REGCOMP],[
+  AC_MSG_CHECKING([whether POSIX compliant regcomp()/regexec()])
+  AC_CACHE_VAL([ax_cv_posix_regcomp],[
+  AC_TRY_RUN([#include <sys/types.h>
+#include <regex.h>
+int main() {
+  int flags = REG_EXTENDED|REG_ICASE|REG_NEWLINE;
+  regex_t  re;
+  if (regcomp( &re, "^.*$", flags ) != 0)
+    return 1;
+  return regcomp( &re, "|no.*", flags ); }],[ax_cv_posix_regcomp=yes],[ax_cv_posix_regcomp=no],[ax_cv_posix_regcomp=no]
+  ) # end of TRY_RUN]) # end of CACHE_VAL
+
+  AC_MSG_RESULT([$ax_cv_posix_regcomp])
+  if test x$ax_cv_posix_regcomp = xyes
+  then
+    AC_DEFINE(HAVE_POSIX_REGCOMP, 1,
+       [Define this if POSIX compliant regcomp()/regexec()])
+  fi
+]) # end of AC_DEFUN of AX_CHECK_POSIX_REGCOMP

--- a/configure.ac
+++ b/configure.ac
@@ -86,6 +86,12 @@ AM_CONDITIONAL([HAVE_CMAKE], [test "x$HAVE_CMAKE" = "xyes"])
 AC_PROG_MAKE_SET
 LT_INIT
 
+# Check for functions.
+AX_CHECK_POSIX_REGCOMP
+AS_IF([test x$ax_cv_posix_regcomp != xyes], [
+	AC_MSG_ERROR([Missing POSIX regex support.])
+])
+
 # rw_PROG_CXX_WORKS
 # Check whether the C++ compiler works.
 AC_CACHE_CHECK([whether the C++ compiler works], [rw_cv_prog_cxx_works], [

--- a/liblttng-ust/lttng-ust-abi.c
+++ b/liblttng-ust/lttng-ust-abi.c
@@ -825,6 +825,38 @@ objd_error:
 	return ret;
 }
 
+/*
+ * Indicates whether or not a given event name contains at least one
+ * non-escaped globbing character.
+ *
+ * Returns 1 if it does.
+ */
+static int event_name_has_glob_char(const char *name)
+{
+	const char *ch = name;
+
+	while (*ch) {
+		switch (*ch) {
+		case '\\':
+			if (ch[1] == '*' || ch[1] == '?' || ch[1] == '\\') {
+				/* Escaped globbing characters: skip. */
+				ch++;
+			}
+			break;
+		case '*':
+		case '?':
+			/* Name has at least one globbing character. */
+			return 1;
+		default:
+			break;
+		}
+
+		ch++;
+	}
+
+	return 0;
+}
+
 /**
  *	lttng_channel_cmd - lttng control through object descriptors
  *
@@ -876,8 +908,11 @@ long lttng_channel_cmd(int objd, unsigned int cmd, unsigned long arg,
 	{
 		struct lttng_ust_event *event_param =
 			(struct lttng_ust_event *) arg;
-		if (event_param->name[strlen(event_param->name) - 1] == '*') {
-			/* If ends with wildcard, create wildcard. */
+		if (event_name_has_glob_char(event_param->name)) {
+			/*
+			 * If it contains non-escaped globbing
+			 * characters, use a wildcard enabler.
+			 */
 			return lttng_abi_create_enabler(objd, event_param,
 					owner, LTTNG_ENABLER_WILDCARD);
 		} else {


### PR DESCRIPTION
Note: currently you need [this patch](http://pastebin.com/DMeenddT) for LTTng-tools to avoid the strict validation of `*` only at the end.