### PR TITLE
lttng-ust-elf.c: define NT_GNU_BUILD_ID if not defined

### DIFF
--- a/liblttng-ust/lttng-ust-elf.c
+++ b/liblttng-ust/lttng-ust-elf.c
@@ -31,6 +31,10 @@
 
 #define BUF_LEN	4096
 
+#ifndef NT_GNU_BUILD_ID
+# define NT_GNU_BUILD_ID	3
+#endif
+
 /*
  * Retrieve the nth (where n is the `index` argument) phdr (program
  * header) from the given elf instance.


### PR DESCRIPTION
We might want to define this at another location, but I'm not sure where.
