### PR TITLE
doc/examples/Makefile.am: define C and C++ compilers for CMake

### DIFF
--- a/doc/examples/Makefile.am
+++ b/doc/examples/Makefile.am
@@ -152,7 +152,9 @@ all-local:
 				cmake \
 				-DCMAKE_INCLUDE_PATH="$(abs_top_srcdir)/include;$(abs_top_builddir)/include" \
 				-DCMAKE_LIBRARY_PATH="$(abs_top_builddir)/liblttng-ust/.libs" \
+				-DCMAKE_C_COMPILER="$(CC)" \
 				-DCMAKE_C_FLAGS="$(CFLAGS) $(CPPFLAGS)" \
+				-DCMAKE_CXX_COMPILER="$(CXX)" \
 				-DCMAKE_CXX_FLAGS="$(CXXFLAGS) $(CPPFLAGS)" \
 				-DCMAKE_EXE_LINKER_FLAGS="$(LDFLAGS)" \
 				.. && \


### PR DESCRIPTION
This prevents build failures when cross-compiling.

If we don't define the compiler, it will use the one from the host
machine. For instance "/usr/bin/c++", which is incorrect.

The failure looks like this:

.............................................................
[ 10%] Building CXX object CMakeFiles/tracepoint-provider.dir/tracepoint-provider.cpp.o
/usr/bin/c++   -Dtracepoint_provider_EXPORTS -I/br/output/build/lttng-libust-2.9.0/doc/examples/cmake-multiple-shared-libraries/. -isystem /br/output/build/lttng-libust-2.9.0/include  -D_LARGEFILE_SOURCE -D_LARGEFILE64_SOURCE -D_FILE_OFFSET_BITS=64  -Os  -D_LARGEFILE_SOURCE -D_LARGEFILE64_SOURCE -D_FILE_OFFSET_BITS=64 -fPIC   -o CMakeFiles/tracepoint-provider.dir/tracepoint-provider.cpp.o -c /br/output/build/lttng-libust-2.9.0/doc/examples/cmake-multiple-shared-libraries/tracepoint-provider.cpp
In file included from /br/output/build/lttng-libust-2.9.0/include/lttng/tracepoint.h:29:0,
                 from /br/output/build/lttng-libust-2.9.0/doc/examples/cmake-multiple-shared-libraries/tracepoint-provider.h:32,
                 from /br/output/build/lttng-libust-2.9.0/doc/examples/cmake-multiple-shared-libraries/tracepoint-provider.cpp:26:
/br/output/build/lttng-libust-2.9.0/include/lttng/tracepoint-rcu.h:26:27: fatal error: urcu/compiler.h: No such file or directory
 #include <urcu/compiler.h>
                           ^
compilation terminated.
.............................................................

Signed-off-by: Vicente Olivert Riera <Vincent.Riera@imgtec.com>