### PR TITLE
doc/man: add typical `$` and `#` prompts to command lines

### DIFF
--- a/doc/man/lttng-ust-cyg-profile.3.txt
+++ b/doc/man/lttng-ust-cyg-profile.3.txt
@@ -18,7 +18,7 @@ Launch your application by preloading
 
 [role="term"]
 [verse]
-*LD_PRELOAD=liblttng-ust-cyg-profile-fast.so* my-app
+$ *LD_PRELOAD=liblttng-ust-cyg-profile-fast.so* my-app
 
 Launch your application by preloading
 `liblttng-ust-cyg-profile.so` for slower, more verbose function
@@ -26,7 +26,7 @@ tracing:
 
 [role="term"]
 [verse]
-*LD_PRELOAD=liblttng-ust-cyg-profile.so* my-app
+$ *LD_PRELOAD=liblttng-ust-cyg-profile.so* my-app
 
 
 DESCRIPTION

--- a/doc/man/lttng-ust-dl.3.txt
+++ b/doc/man/lttng-ust-dl.3.txt
@@ -14,7 +14,7 @@ Launch your application by preloading `liblttng-ust-dl.so`:
 
 [role="term"]
 [verse]
-*LD_PRELOAD=liblttng-ust-dl.so* my-app
+$ *LD_PRELOAD=liblttng-ust-dl.so* my-app
 
 
 DESCRIPTION

--- a/doc/man/lttng-ust.3.txt
+++ b/doc/man/lttng-ust.3.txt
@@ -605,9 +605,9 @@ source:
 Create the tracepoint provider object file:
 
 [role="term"]
---------------
-cc -c -I. tp.c
---------------
+----
+$ cc -c -I. tp.c
+----
 
 NOTE: Although an application instrumented with LTTng-UST tracepoints
 can be compiled with a C++ compiler, tracepoint probes should be
@@ -618,9 +618,9 @@ possibly with other object files of your application or with other
 tracepoint provider object files, as a static library:
 
 [role="term"]
----------------
-ar rc tp.a tp.o
----------------
+----
+$ ar rc tp.a tp.o
+----
 
 Using a static library does have the advantage of centralising the
 tracepoint providers objects so they can be shared between multiple
@@ -635,9 +635,9 @@ library containing it) and with `liblttng-ust` and `libdl`
 (`libc` on a BSD system):
 
 [role="term"]
--------------------------------------
-cc -o app tp.o app.o -llttng-ust -ldl
--------------------------------------
+----
+$ cc -o app tp.o app.o -llttng-ust -ldl
+----
 
 
 [[build-dynamic]]
@@ -678,16 +678,16 @@ built like it is using the static linking method, but with the
 nloption:-fpic option:
 
 [role="term"]
---------------------
-cc -c -fpic -I. tp.c
---------------------
+----
+$ cc -c -fpic -I. tp.c
+----
 
 It is then linked as a shared library like this:
 
 [role="term"]
--------------------------------------------------------
-cc -shared -Wl,--no-as-needed -o tp.so tp.o -llttng-ust
--------------------------------------------------------
+----
+$ cc -shared -Wl,--no-as-needed -o tp.so tp.o -llttng-ust
+----
 
 This tracepoint provider shared object isn't linked with the user
 application: it must be loaded manually. This is why the application is
@@ -695,9 +695,9 @@ built with no mention of this tracepoint provider, but still needs
 libdl:
 
 [role="term"]
---------------------------------
-cc -o app app.o tp-define.o -ldl
---------------------------------
+----
+$ cc -o app app.o tp-define.o -ldl
+----
 
 There are two ways to dynamically load the tracepoint provider shared
 object:
@@ -1033,44 +1033,44 @@ You can compile the source files and link them together statically
 like this:
 
 [role="term"]
--------------------------------------
-cc -c -I. tp.c
-cc -c app.c
-cc -o app tp.o app.o -llttng-ust -ldl
--------------------------------------
+----
+$ cc -c -I. tp.c
+$ cc -c app.c
+$ cc -o app tp.o app.o -llttng-ust -ldl
+----
 
 Using the man:lttng(1) tool, create an LTTng tracing session, enable
 all the events of this tracepoint provider, and start tracing:
 
 [role="term"]
-----------------------------------------------
-lttng create my-session
-lttng enable-event --userspace 'my_provider:*'
-lttng start
-----------------------------------------------
+----
+$ lttng create my-session
+$ lttng enable-event --userspace 'my_provider:*'
+$ lttng start
+----
 
 You may also enable specific events:
 
 [role="term"]
-----------------------------------------------------------
-lttng enable-event --userspace my_provider:big_event
-lttng enable-event --userspace my_provider:event_instance2
-----------------------------------------------------------
+----
+$ lttng enable-event --userspace my_provider:big_event
+$ lttng enable-event --userspace my_provider:event_instance2
+----
 
 Run the application:
 
 [role="term"]
---------------------
-./app some arguments
---------------------
+----
+$ ./app some arguments
+----
 
 Stop the current tracing session and inspect the recorded events:
 
 [role="term"]
-----------
-lttng stop
-lttng view
-----------
+----
+$ lttng stop
+$ lttng view
+----
 
 
 Tracepoint provider header file

--- a/doc/man/tracef.3.txt
+++ b/doc/man/tracef.3.txt
@@ -69,34 +69,34 @@ This C source file, saved as `app.c`, can be compiled into a program
 like this:
 
 [role="term"]
----------------------------
-cc -o app app.c -llttng-ust
----------------------------
+----
+$ cc -o app app.c -llttng-ust
+----
 
 You can create an LTTng tracing session, enable the `tracef()` events,
 and start the created tracing session like this:
 
 [role="term"]
----------------------------------------------------
-lttng create my-session
-lttng enable-event --userspace 'lttng_ust_tracef:*'
-lttng start
----------------------------------------------------
+----
+$ lttng create my-session
+$ lttng enable-event --userspace 'lttng_ust_tracef:*'
+$ lttng start
+----
 
 Next, start the program to be traced:
 
 [role="term"]
------
-./app
------
+----
+$ ./app
+----
 
 Finally, stop the tracing session, and inspect the recorded events:
 
 [role="term"]
-----------
-lttng stop
-lttng view
-----------
+----
+$ lttng stop
+$ lttng view
+----
 
 
 [[limitations]]

--- a/doc/man/tracelog.3.txt
+++ b/doc/man/tracelog.3.txt
@@ -104,43 +104,43 @@ This C source file, saved as `app.c`, can be compiled into a program
 like this:
 
 [role="term"]
----------------------------
-cc -o app app.c -llttng-ust
----------------------------
+----
+$ cc -o app app.c -llttng-ust
+----
 
 You can create an LTTng tracing session, enable all the `tracelog()`
 events, and start the created tracing session like this:
 
 [role="term"]
----------------------------------------------------
-lttng create my-session
-lttng enable-event --userspace 'lttng_ust_tracelog:*'
-lttng start
----------------------------------------------------
+----
+$ lttng create my-session
+$ lttng enable-event --userspace 'lttng_ust_tracelog:*'
+$ lttng start
+----
 
 Or you can enable `tracelog()` events matching a log level at least
 as severe as a given log level:
 
 [role="term"]
--------------------------------------------------------
-lttng enable-event --userspace 'lttng_ust_tracelog:*' \
+----
+$ lttng enable-event --userspace 'lttng_ust_tracelog:*' \
                    --loglevel=TRACE_INFO
--------------------------------------------------------
+----
 
 Next, start the program to be traced:
 
 [role="term"]
-------------------------------------------------
-./app a few arguments passed to this application
-------------------------------------------------
+----
+$ ./app a few arguments passed to this application
+----
 
 Finally, stop the tracing session, and inspect the recorded events:
 
 [role="term"]
-----------
-lttng stop
-lttng view
-----------
+----
+$ lttng stop
+$ lttng view
+----
 
 
 [[limitations]]


### PR DESCRIPTION
It is more instinctive for the typical reader to immediately recognize
command lines when they start with the classic prompts.

On the online version of the man pages, those prompts are treated
specially to make them non-selectable. This makes it possible to copy
multiple command lines at once (without copying the prompts) and to
paste them to your shell.