### PR TITLE
dlclose() support

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -25,6 +25,7 @@ m4_define([UST_LIB_V_MINOR], [0])
 m4_define([UST_LIB_V_PATCH], [0])
 
 AC_SUBST([LTTNG_UST_LIBRARY_VERSION], [UST_LIB_V_MAJOR:UST_LIB_V_MINOR:UST_LIB_V_PATCH])
+AC_SUBST([LTTNG_UST_LIBRARY_VERSION_MAJOR], [UST_LIB_V_MAJOR])
 # note: remember to update tracepoint.h dlopen() to match this version
 # number. TODO: eventually automate by exporting the major number.
 

--- a/configure.ac
+++ b/configure.ac
@@ -20,7 +20,11 @@ AC_SUBST([PATCHLEVEL_VERSION], [V_PATCH])
 # Following the numbering scheme proposed by libtool for the library version
 # http://www.gnu.org/software/libtool/manual/html_node/Updating-version-info.html
 # This is the library version of liblttng-ust.
-AC_SUBST([LTTNG_UST_LIBRARY_VERSION], [0:0:0])
+m4_define([UST_LIB_V_MAJOR], [0])
+m4_define([UST_LIB_V_MINOR], [0])
+m4_define([UST_LIB_V_PATCH], [0])
+
+AC_SUBST([LTTNG_UST_LIBRARY_VERSION], [UST_LIB_V_MAJOR:UST_LIB_V_MINOR:UST_LIB_V_PATCH])
 # note: remember to update tracepoint.h dlopen() to match this version
 # number. TODO: eventually automate by exporting the major number.
 

--- a/include/lttng/ust-events.h
+++ b/include/lttng/ust-events.h
@@ -656,6 +656,7 @@ void synchronize_trace(void);
 
 int lttng_probe_register(struct lttng_probe_desc *desc);
 void lttng_probe_unregister(struct lttng_probe_desc *desc);
+void lttng_probe_provider_unregister_events(struct lttng_probe_desc *desc);
 int lttng_fix_pending_events(void);
 int lttng_probes_init(void);
 void lttng_probes_exit(void);

--- a/include/lttng/ust-events.h
+++ b/include/lttng/ust-events.h
@@ -731,8 +731,9 @@ int lttng_session_active(void);
 typedef int (*t_statedump_func_ptr)(struct lttng_session *session);
 void lttng_handle_pending_statedump(void *owner);
 struct cds_list_head *_lttng_get_sessions(void);
-struct lttng_enum *lttng_ust_enum_get(struct lttng_session *session,
-		const char *enum_name);
+
+struct lttng_enum *lttng_ust_enum_get_from_desc(struct lttng_session *session,
+		const struct lttng_enum_desc *enum_desc);
 
 void lttng_ust_dl_update(void *ip);
 void lttng_ust_fixup_fd_tracker_tls(void);

--- a/include/lttng/ust-tracepoint-event.h
+++ b/include/lttng/ust-tracepoint-event.h
@@ -1007,7 +1007,7 @@ _TP_COMBINE_TOKENS(__lttng_events_init__, TRACEPOINT_PROVIDER)(void)
 	_TP_COMBINE_TOKENS(__tracepoint_provider_check_, TRACEPOINT_PROVIDER)();
 	ret = lttng_probe_register(&_TP_COMBINE_TOKENS(__probe_desc___, TRACEPOINT_PROVIDER));
 	if (ret) {
-		fprintf(stderr, "LTTng-UST: Error (%d) while registering tracepoint probe. Duplicate registration of tracepoint probes having the same name is not allowed.\n", ret);
+		fprintf(stderr, "LTTng-UST: Error (%d) while registering tracepoint probe.\n", ret);
 		abort();
 	}
 }

--- a/liblttng-ust-comm/lttng-ust-comm.c
+++ b/liblttng-ust-comm/lttng-ust-comm.c
@@ -874,8 +874,7 @@ int serialize_basic_type(struct lttng_session *session,
 		if (session) {
 			const struct lttng_enum *_enum;
 
-			_enum = lttng_ust_enum_get(session,
-					lbt->enumeration.desc->name);
+			_enum = lttng_ust_enum_get_from_desc(session, lbt->enumeration.desc);
 			if (!_enum)
 				return -EINVAL;
 			ubt->enumeration.id = _enum->id;

--- a/liblttng-ust/Makefile.am
+++ b/liblttng-ust/Makefile.am
@@ -60,6 +60,8 @@ liblttng_ust_runtime_la_SOURCES = \
 	string-utils.c \
 	string-utils.h
 
+liblttng_ust_runtime_la_CFLAGS = -DLTTNG_UST_LIBRARY_VERSION_MAJOR=\"$(LTTNG_UST_LIBRARY_VERSION_MAJOR)\"
+
 if HAVE_PERF_EVENT
 liblttng_ust_runtime_la_SOURCES += \
 	lttng-context-perf-counters.c \

--- a/liblttng-ust/lttng-events.c
+++ b/liblttng-ust/lttng-events.c
@@ -546,15 +546,6 @@ int lttng_event_create(const struct lttng_event_desc *desc,
 
 	hash = jhash(event_name, name_len, 0);
 	head = &chan->session->events_ht.table[hash & (LTTNG_UST_EVENT_HT_SIZE - 1)];
-	cds_hlist_for_each_entry(event, node, head, hlist) {
-		assert(event->desc);
-		if (!strncmp(event->desc->name, desc->name,
-					LTTNG_UST_SYM_NAME_LEN - 1)
-				&& chan == event->chan) {
-			ret = -EEXIST;
-			goto exist;
-		}
-	}
 
 	notify_socket = lttng_get_notify_socket(session->owner);
 	if (notify_socket < 0) {

--- a/liblttng-ust/lttng-events.c
+++ b/liblttng-ust/lttng-events.c
@@ -885,7 +885,11 @@ void _lttng_event_destroy(struct lttng_event *event)
 {
 	struct lttng_enabler_ref *enabler_ref, *tmp_enabler_ref;
 
+	/* Remove from event list. */
 	cds_list_del(&event->node);
+	/* Remove from event hash table. */
+	cds_hlist_del(&event->hlist);
+
 	lttng_destroy_context(event->ctx);
 	lttng_free_event_filter_runtime(event);
 	/* Free event enabler refs */

--- a/liblttng-ust/lttng-events.c
+++ b/liblttng-ust/lttng-events.c
@@ -537,7 +537,6 @@ int lttng_event_create(const struct lttng_event_desc *desc,
 	struct lttng_event *event;
 	struct lttng_session *session = chan->session;
 	struct cds_hlist_head *head;
-	struct cds_hlist_node *node;
 	int ret = 0;
 	size_t name_len = strlen(event_name);
 	uint32_t hash;
@@ -614,7 +613,6 @@ sessiond_register_error:
 cache_error:
 create_enum_error:
 socket_error:
-exist:
 	return ret;
 }
 

--- a/liblttng-ust/lttng-events.c
+++ b/liblttng-ust/lttng-events.c
@@ -990,6 +990,7 @@ static
 void _lttng_enum_destroy(struct lttng_enum *_enum)
 {
 	cds_list_del(&_enum->node);
+	cds_hlist_del(&_enum->hlist);
 	free(_enum);
 }
 

--- a/liblttng-ust/lttng-events.c
+++ b/liblttng-ust/lttng-events.c
@@ -867,10 +867,7 @@ void lttng_probe_provider_unregister_events(struct lttng_probe_desc *provider_de
 			head = &session->events_ht.table[hash & (LTTNG_UST_EVENT_HT_SIZE - 1)];
 			cds_hlist_for_each_entry(event, node, head, hlist) {
 				if (event_desc == event->desc) {
-					/* Destroy event. */
-					_lttng_event_destroy(event);
-
-					/* Destroy enums. */
+					/* Destroy enums of the current event. */
 					for (j = 0; j < event->desc->nr_fields; j++) {
 						const struct lttng_event_field *field;
 						const struct lttng_enum_desc *enum_desc;
@@ -887,6 +884,10 @@ void lttng_probe_provider_unregister_events(struct lttng_probe_desc *provider_de
 							_lttng_enum_destroy(curr_enum);
 						}
 					}
+
+					/* Destroy event. */
+					_lttng_event_destroy(event);
+
 					break;
 				}
 			}

--- a/liblttng-ust/lttng-probes.c
+++ b/liblttng-ust/lttng-probes.c
@@ -226,7 +226,10 @@ void lttng_probe_unregister(struct lttng_probe_desc *desc)
 		cds_list_del(&desc->head);
 	else
 		cds_list_del(&desc->lazy_init_head);
-	DBG("just unregistered probe %s", desc->provider);
+
+	lttng_probe_provider_unregister_events(desc);
+	DBG("just unregistered probes of provider %s", desc->provider);
+
 	ust_unlock();
 }
 

--- a/liblttng-ust/lttng-probes.c
+++ b/liblttng-ust/lttng-probes.c
@@ -148,20 +148,6 @@ struct cds_list_head *lttng_get_probe_list_head(void)
 }
 
 static
-const struct lttng_probe_desc *find_provider(const char *provider)
-{
-	struct lttng_probe_desc *iter;
-	struct cds_list_head *probe_list;
-
-	probe_list = lttng_get_probe_list_head();
-	cds_list_for_each_entry(iter, probe_list, head) {
-		if (!strcmp(iter->provider, provider))
-			return iter;
-	}
-	return NULL;
-}
-
-static
 int check_provider_version(struct lttng_probe_desc *desc)
 {
 	/*
@@ -206,13 +192,6 @@ int lttng_probe_register(struct lttng_probe_desc *desc)
 
 	ust_lock_nocheck();
 
-	/*
-	 * Check if the provider has already been registered.
-	 */
-	if (find_provider(desc->provider)) {
-		ret = -EEXIST;
-		goto end;
-	}
 	cds_list_add(&desc->lazy_init_head, &lazy_probe_init);
 	desc->lazy = 1;
 	DBG("adding probe %s containing %u events to lazy registration list",

--- a/liblttng-ust/lttng-probes.c
+++ b/liblttng-ust/lttng-probes.c
@@ -203,7 +203,7 @@ int lttng_probe_register(struct lttng_probe_desc *desc)
 	 */
 	if (lttng_session_active())
 		fixup_lazy_probes();
-end:
+
 	ust_unlock();
 	return ret;
 }

--- a/liblttng-ust/tracepoint.c
+++ b/liblttng-ust/tracepoint.c
@@ -107,8 +107,8 @@ struct tracepoint_entry {
 	struct lttng_ust_tracepoint_probe *probes;
 	int refcount;	/* Number of times armed. 0 if disarmed. */
 	int callsite_refcount;	/* how many libs use this tracepoint */
-	const char *signature;
-	char name[0];
+	char *signature;
+	char *name;
 };
 
 struct tp_probes {
@@ -132,6 +132,7 @@ struct callsite_entry {
 	struct cds_hlist_node hlist;	/* hash table node */
 	struct cds_list_head node;	/* lib list of callsites node */
 	struct lttng_ust_tracepoint *tp;
+	bool tp_entry_callsite_ref; /* Has a tp_entry took a ref on this callsite*/
 };
 
 /* coverity[+alloc] */
@@ -284,6 +285,8 @@ static struct tracepoint_entry *add_tracepoint(const char *name,
 	struct cds_hlist_node *node;
 	struct tracepoint_entry *e;
 	size_t name_len = strlen(name);
+	size_t sig_len = strlen(signature);
+	size_t sig_off, name_off;
 	uint32_t hash;
 
 	if (name_len > LTTNG_UST_SYM_NAME_LEN - 1) {
@@ -298,19 +301,29 @@ static struct tracepoint_entry *add_tracepoint(const char *name,
 			return ERR_PTR(-EEXIST);	/* Already there */
 		}
 	}
+
 	/*
-	 * Using zmalloc here to allocate a variable length element. Could
-	 * cause some memory fragmentation if overused.
+	 * Using zmalloc here to allocate a variable length elements: name and
+	 * signature. Could cause some memory fragmentation if overused.
 	 */
-	e = zmalloc(sizeof(struct tracepoint_entry) + name_len + 1);
+	name_off = sizeof(struct tracepoint_entry);
+	sig_off = name_off + name_len + 1;
+
+	e = zmalloc(sizeof(struct tracepoint_entry) + name_len + 1 + sig_len + 1);
 	if (!e)
 		return ERR_PTR(-ENOMEM);
-	memcpy(&e->name[0], name, name_len + 1);
+	e->name = (char *) e + name_off;
+	memcpy(e->name, name, name_len + 1);
 	e->name[name_len] = '\0';
+
+	e->signature = (char *) e + sig_off;
+	memcpy(e->signature, signature, sig_len + 1);
+	e->signature[sig_len] = '\0';
+
 	e->probes = NULL;
 	e->refcount = 0;
 	e->callsite_refcount = 0;
-	e->signature = signature;
+
 	cds_hlist_add_head(&e->hlist, head);
 	return e;
 }
@@ -405,6 +418,7 @@ static void add_callsite(struct tracepoint_lib * lib, struct lttng_ust_tracepoin
 	if (!tp_entry)
 		return;
 	tp_entry->callsite_refcount++;
+	e->tp_entry_callsite_ref = true;
 }
 
 /*
@@ -417,7 +431,8 @@ static void remove_callsite(struct callsite_entry *e)
 
 	tp_entry = get_tracepoint(e->tp->name);
 	if (tp_entry) {
-		tp_entry->callsite_refcount--;
+		if (e->tp_entry_callsite_ref)
+			tp_entry->callsite_refcount--;
 		if (tp_entry->callsite_refcount == 0)
 			disable_tracepoint(e->tp);
 	}
@@ -453,10 +468,15 @@ static void tracepoint_sync_callsites(const char *name)
 		if (strncmp(name, tp->name, LTTNG_UST_SYM_NAME_LEN - 1))
 			continue;
 		if (tp_entry) {
+			if (!e->tp_entry_callsite_ref) {
+				tp_entry->callsite_refcount++;
+				e->tp_entry_callsite_ref = true;
+			}
 			set_tracepoint(&tp_entry, tp,
 					!!tp_entry->refcount);
 		} else {
 			disable_tracepoint(tp);
+			e->tp_entry_callsite_ref = false;
 		}
 	}
 }
@@ -545,7 +565,12 @@ tracepoint_add_probe(const char *name, void (*probe)(void), void *data,
 	struct lttng_ust_tracepoint_probe *old;
 
 	entry = get_tracepoint(name);
-	if (!entry) {
+	if (entry) {
+		if (strcmp(entry->signature, signature) != 0) {
+			ERR("Tracepoint and probe signature do not match.");
+			return ERR_PTR(-EINVAL);
+		}
+	} else {
 		entry = add_tracepoint(name, signature);
 		if (IS_ERR(entry))
 			return (struct lttng_ust_tracepoint_probe *)entry;

--- a/liblttng-ust/ust-core.c
+++ b/liblttng-ust/ust-core.c
@@ -63,21 +63,20 @@ void lttng_transport_unregister(struct lttng_transport *transport)
 /*
  * Needed by comm layer.
  */
-struct lttng_enum *lttng_ust_enum_get(struct lttng_session *session,
-		const char *enum_name)
+struct lttng_enum *lttng_ust_enum_get_from_desc(struct lttng_session *session,
+		const struct lttng_enum_desc *enum_desc)
 {
 	struct lttng_enum *_enum;
 	struct cds_hlist_head *head;
 	struct cds_hlist_node *node;
-	size_t name_len = strlen(enum_name);
+	size_t name_len = strlen(enum_desc->name);
 	uint32_t hash;
 
-	hash = jhash(enum_name, name_len, 0);
+	hash = jhash(enum_desc->name, name_len, 0);
 	head = &session->enums_ht.table[hash & (LTTNG_UST_ENUM_HT_SIZE - 1)];
 	cds_hlist_for_each_entry(_enum, node, head, hlist) {
 		assert(_enum->desc);
-		if (!strncmp(_enum->desc->name, enum_name,
-				LTTNG_UST_SYM_NAME_LEN - 1))
+		if (_enum->desc == enum_desc)
 			return _enum;
 	}
 	return NULL;


### PR DESCRIPTION
This patch allows for the unloading of probe providers using dlclose().