### PR TITLE
Fix: Update coding style link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,7 @@ control. The upstream Git repository URL is:
 ## Coding standard
 
 LTTng-UST uses the
-[Linux kernel coding style](http://www.kernel.org/doc/Documentation/CodingStyle).
+[Linux kernel coding style](https://www.kernel.org/doc/html/latest/process/coding-style.html).
 
 Although the LTTng-UST code base is primarily written in C, it does
 contain shell, Perl, and Python code as well. There is no official coding


### PR DESCRIPTION
The documentation at kernel.org changed and the coding style has
moved.