### PR TITLE
python-lttngust/Makefile.am: Add --install-lib to setup.py

### DIFF
--- a/python-lttngust/Makefile.am
+++ b/python-lttngust/Makefile.am
@@ -9,7 +9,7 @@ install-exec-local:
 	if [ "$(DESTDIR)" != "" ]; then \
 		opts="$$opts --root=$(DESTDIR)"; \
 	fi; \
-	$(PYTHON) setup.py install $$opts;
+	$(PYTHON) setup.py install $$opts --install-lib=$(pythondir);
 
 clean-local:
 	rm -rf $(builddir)/build


### PR DESCRIPTION
Otherwise it may install to /usr/lib, but should be /usr/lib64 when cross
building.

Upstream-Status: Pending

Signed-off-by: Robert Yang <liezhi.yang@windriver.com>