### PR TITLE
Add procname to lttng_ust_statedump information

### DIFF
--- a/doc/man/lttng-ust.3.txt
+++ b/doc/man/lttng-ust.3.txt
@@ -952,6 +952,20 @@ Fields:
 |Debug link file name.
 |===
 
+`lttng_ust_statedump:procname`::
+    The process procname at process start.
++
+Fields:
++
+[options="header"]
+|===
+|Field name |Description
+
+|`procname`
+|The process name.
+
+|===
+
 
 [[ust-lib]]
 Shared library load/unload tracking
@@ -1393,6 +1407,10 @@ Default: {lttng_ust_register_timeout}.
 
 `LTTNG_UST_WITHOUT_BADDR_STATEDUMP`::
     If set, prevents `liblttng-ust` from performing a base address state
+    dump (see the <<state-dump,LTTng-UST state dump>> section above).
+
+`LTTNG_UST_WITHOUT_PROCNAME_STATEDUMP`::
+    If set, prevents `liblttng-ust` from performing a procname state
     dump (see the <<state-dump,LTTng-UST state dump>> section above).
 
 

--- a/include/helper.h
+++ b/include/helper.h
@@ -55,4 +55,15 @@ void *zmalloc(size_t len)
 #define LTTNG_UST_CALLER_IP()		__builtin_return_address(0)
 #endif /* #else #if defined(__PPC__) && !defined(__PPC64__) */
 
+/*
+ * LTTNG_HIDDEN: set the hidden attribute for internal functions
+ * On Windows, symbols are local unless explicitly exported,
+ * see https://gcc.gnu.org/wiki/Visibility
+ */
+#if defined(_WIN32) || defined(__CYGWIN__)
+#define LTTNG_HIDDEN
+#else
+#define LTTNG_HIDDEN __attribute__((visibility("hidden")))
+#endif
+
 #endif /* _LTTNG_UST_HELPER_H */

--- a/liblttng-ust/lttng-tracer-core.h
+++ b/liblttng-ust/lttng-tracer-core.h
@@ -29,6 +29,7 @@
 #include <lttng/bug.h>
 #include <lttng/ringbuffer-config.h>
 #include <usterr-signal-safe.h>
+#include <helper.h>
 
 /*
  * The longuest possible namespace proc path is with the cgroup ns
@@ -60,6 +61,9 @@ void lttng_fixup_uts_ns_tls(void);
 const char *lttng_ust_obj_get_name(int id);
 
 int lttng_get_notify_socket(void *owner);
+
+LTTNG_HIDDEN
+char* lttng_ust_sockinfo_get_procname(void *owner);
 
 void lttng_ust_sockinfo_session_enabled(void *owner);
 

--- a/liblttng-ust/lttng-ust-comm.c
+++ b/liblttng-ust/lttng-ust-comm.c
@@ -263,6 +263,8 @@ struct sock_info {
 	/* Keep track of lazy state dump not performed yet. */
 	int statedump_pending;
 	int initial_statedump_done;
+	/* Keep procname for statedump */
+	char procname[LTTNG_UST_PROCNAME_LEN];
 };
 
 /* Socket from app (connect) to session daemon (listen) for communication */
@@ -283,6 +285,7 @@ struct sock_info global_apps = {
 
 	.statedump_pending = 0,
 	.initial_statedump_done = 0,
+	.procname[0] = '\0'
 };
 
 /* TODO: allow global_apps_sock_path override */
@@ -300,6 +303,7 @@ struct sock_info local_apps = {
 
 	.statedump_pending = 0,
 	.initial_statedump_done = 0,
+	.procname[0] = '\0'
 };
 
 static int wait_poll_fallback;
@@ -438,6 +442,15 @@ int lttng_get_notify_socket(void *owner)
 	return info->notify_socket;
 }
 
+
+LTTNG_HIDDEN
+char* lttng_ust_sockinfo_get_procname(void *owner)
+{
+	struct sock_info *info = owner;
+
+	return info->procname;
+}
+
 static
 void print_cmd(int cmd, int handle)
 {
@@ -467,6 +480,7 @@ int setup_global_apps(void)
 	}
 
 	global_apps.allowed = 1;
+	lttng_ust_getprocname(global_apps.procname);
 error:
 	return ret;
 }
@@ -511,6 +525,8 @@ int setup_local_apps(void)
 		ret = -EIO;
 		goto end;
 	}
+
+	lttng_ust_getprocname(local_apps.procname);
 end:
 	return ret;
 }

--- a/liblttng-ust/lttng-ust-statedump-provider.h
+++ b/liblttng-ust/lttng-ust-statedump-provider.h
@@ -34,6 +34,7 @@ extern "C" {
 #include <stdint.h>
 #include <unistd.h>
 #include <lttng/ust-events.h>
+#include "compat.h"
 
 #define LTTNG_UST_STATEDUMP_PROVIDER
 #include <lttng/tracepoint.h>
@@ -88,6 +89,16 @@ TRACEPOINT_EVENT(lttng_ust_statedump, debug_link,
 		ctf_integer_hex(void *, baddr, baddr)
 		ctf_integer(uint32_t, crc, crc)
 		ctf_string(filename, filename)
+	)
+)
+
+TRACEPOINT_EVENT(lttng_ust_statedump, procname,
+	TP_ARGS(
+		struct lttng_session *, session,
+		char *, name
+	),
+	TP_FIELDS(
+		ctf_array_text(char, procname, name, LTTNG_UST_PROCNAME_LEN)
 	)
 )
 


### PR DESCRIPTION
Adding the process procname to the statedump allows users to disable
procname context in scenario for which the data and serialization overhead
of the procname process is problematic. Users can stitch information in
post-processing based on other contexts (pid).

Users can skip this statedump via the
LTTNG_UST_WITHOUT_PROCNAME_STATEDUMP env variable.

Note that the procname statedump value is the procname seen at
application start (lttng_ust_init). Subsequent calls to pthread_setname_np
or equivalent have no effect on this value.

Since we cannot use the current thread name due to the
lttng_pthread_setname_np call in ust_listener_thread, we store the
process name inside the sock_info struct before the call to
lttng_pthread_setname_np. This data structure is already present as the
"owner" object in the statedump mechanism. During the statedump, we fetch
the procname from the "owner" object.

Use LTTNG_HIDDEN to reduce visibility of lttng_ust_sockinfo_get_procname.

Signed-off-by: Jonathan Rajotte <jonathan.rajotte-julien@efficios.com>