### PR TITLE
Fix: Use negative value for error code of lttng_ust_ctl_duplicate_ust_object_data

### DIFF
--- a/src/lib/lttng-ust-ctl/ustctl.c
+++ b/src/lib/lttng-ust-ctl/ustctl.c
@@ -1257,7 +1257,7 @@ int lttng_ust_ctl_duplicate_ust_object_data(struct lttng_ust_abi_object_data **d
 			obj->u.channel.wakeup_fd =
 				dup(src->u.channel.wakeup_fd);
 			if (obj->u.channel.wakeup_fd < 0) {
-				ret = errno;
+				ret = -errno;
 				goto chan_error_wakeup_fd;
 			}
 		} else {
@@ -1293,7 +1293,7 @@ int lttng_ust_ctl_duplicate_ust_object_data(struct lttng_ust_abi_object_data **d
 			obj->u.stream.wakeup_fd =
 				dup(src->u.stream.wakeup_fd);
 			if (obj->u.stream.wakeup_fd < 0) {
-				ret = errno;
+				ret = -errno;
 				goto stream_error_wakeup_fd;
 			}
 		} else {
@@ -1305,7 +1305,7 @@ int lttng_ust_ctl_duplicate_ust_object_data(struct lttng_ust_abi_object_data **d
 			obj->u.stream.shm_fd =
 				dup(src->u.stream.shm_fd);
 			if (obj->u.stream.shm_fd < 0) {
-				ret = errno;
+				ret = -errno;
 				goto stream_error_shm_fd;
 			}
 		} else {
@@ -1344,7 +1344,7 @@ int lttng_ust_ctl_duplicate_ust_object_data(struct lttng_ust_abi_object_data **d
 			obj->u.counter_global.shm_fd =
 				dup(src->u.counter_global.shm_fd);
 			if (obj->u.counter_global.shm_fd < 0) {
-				ret = errno;
+				ret = -errno;
 				goto error_type;
 			}
 		}
@@ -1358,7 +1358,7 @@ int lttng_ust_ctl_duplicate_ust_object_data(struct lttng_ust_abi_object_data **d
 			obj->u.counter_cpu.shm_fd =
 				dup(src->u.counter_cpu.shm_fd);
 			if (obj->u.counter_cpu.shm_fd < 0) {
-				ret = errno;
+				ret = -errno;
 				goto error_type;
 			}
 		}


### PR DESCRIPTION
# As is
- `lttng_ust_ctl_duplicate_ust_object_data` function is called by the following functions:
  - `event_notifier_error_accounting_register_app` (lttng-tools)
  - `duplicate_stream_object` (lttng-tools)
  - `duplicate_channel_object` (lttng-tools)
- `lttng_ust_ctl_duplicate_ust_object_data` function returns positive value (= errno ＝ 24 = EMFILE) when system call `dup` returns error
- However, `duplicate_stream_object` and `duplicate_channel_object` functions expect negative value as error code
- As a reslt, these functions cannot handle error and segmenation fault occurs when using `stream->handle` 

# Proposal
- Currently, `lttng_ust_ctl_duplicate_ust_object_data` function returns either positive or negative value when error happens
- It looks convention is using negative value for error code (e.g. `-ENOMEM` )
- So, I propose to change `errno` to `-errno`

# Other information
- When the problem actually occurs?
    - LTTng calls `dup` many times (> `ulimit -n` ) when it traces lots of processes
    - Especially after LTTng 2.13, `dup` is called for the same number as processor cores per target process (or thread?)
- I think LTTng runs as kernel daemon in most cases, and nofile is usually unlimited. So this problem doesn't happen. However, when I manually run `lttng-sessiond` without `sudo` for debugging, the problem easily happens