### PR TITLE
Makefile.am: Add -rpath-link for doc/example cmake

### DIFF
--- a/doc/examples/Makefile.am
+++ b/doc/examples/Makefile.am
@@ -225,7 +225,7 @@ all-local:
 					-DCMAKE_LIBRARY_PATH="$(abs_top_builddir)/src/lib/lttng-ust/.libs" \
 					-DCMAKE_C_FLAGS="$(AM_CFLAGS) $(CPPFLAGS) $(CFLAGS)" \
 					-DCMAKE_CXX_FLAGS="$(AM_CXXFLAGS) $(CXXFLAGS) $(CPPFLAGS)" \
-					-DCMAKE_EXE_LINKER_FLAGS="$(AM_LDFLAGS) $(LDFLAGS)" \
+					-DCMAKE_EXE_LINKER_FLAGS="$(AM_LDFLAGS) -Wl,-rpath-link=\"$(abs_top_builddir)/src/lib/lttng-ust/.libs:$(abs_top_builddir)/src/lib/lttng-ust-tracepoint/.libs/:$(abs_top_builddir)/src/lib/lttng-ust-common/.libs/\" $(LDFLAGS)" \
 					.. && \
 				$(MAKE) \
 			) || exit 1; \


### PR DESCRIPTION
When lttng-ust is built in the Yocto project that is a cross-compile environment. The 'cmake-multiple-shared-libraries' folder was not compiled before lttng-ust-2.13.8 since cmake was not enabled. But in lttng-ust-2.13.8, its dependency has changed. cmake-native was introduced after python3 using the system expat. And there is a new dependency chain [python3-native, expat-native, cmake-native]. So make is enabled by default and the following linking errors happened when compiling the 'cmake-multiple-shared-libraries' folder.
ld: warning: liblttng-ust-common.so.1, needed by ../../../src/lib/lttng-ust/.libs/liblttng-ust.so, not found (try using -rpath or -rpath-link)
ld: warning: liblttng-ust-tracepoint.so.1, needed by ../../../src/lib/lttng-ust/.libs/liblttng-ust.so, not found (try using -rpath or -rpath-link)