### PR TITLE
Fix: stream_instance_id in terminal packets for PER_CHANNEL buffers

### DIFF
--- a/src/common/ringbuffer-clients/template.h
+++ b/src/common/ringbuffer-clients/template.h
@@ -692,7 +692,11 @@ static int client_packet_initialize(struct lttng_ust_ring_buffer *buf,
 	packet_header->magic = CTF_MAGIC_NUMBER;
 	memcpy(packet_header->uuid, lttng_chan_buf->priv->uuid, sizeof(lttng_chan_buf->priv->uuid));
 	packet_header->stream_id = lttng_chan_buf->priv->id;
+#ifdef RING_BUFFER_CLIENT_HAS_CPU_ID
 	packet_header->stream_instance_id = buf->backend.cpu;
+#else
+	packet_header->stream_instance_id = 0;
+#endif
 	packet_header->ctx.timestamp_begin = timestamp_begin;
 	packet_header->ctx.timestamp_end = timestamp_end;
 	packet_header->ctx.content_size = client_packet_header_size() * CHAR_BIT;


### PR DESCRIPTION
client_packet_initialize() was writing stream_instance_id = buf->backend.cpu unconditionally. For PER_CHANNEL buffers, cpu is set to -1, which produces 0xFFFFFFFFFFFFFFFF in the packet header.

client_buffer_begin() already has the correct #ifdef guard:

```
  #ifdef RING_BUFFER_CLIENT_HAS_CPU_ID
      header->stream_instance_id = buf->backend.cpu;
  #else
      header->stream_instance_id = 0;
  #endif
```

client_packet_initialize() is called to write a terminal packet when a snapshot flush produces no new data and this happens when the channel is idle and pos_before == pos_after after the flush. The terminal packet records the current timestamp so that trace readers know the trace was active up to that point, even if no events were emitted. Its timestamp_begin and timestamp_end are equal and its content size equals the packet header size (no events).

Because client_buffer_begin() correctly writes stream_instance_id = 0 for PER_CHANNEL clients but client_packet_initialize() does not, a snapshot from a low-activity PER_CHANNEL channel ends up with two packets whose stream_instance_id values disagree: the real packet has 0 and the terminal packet has 0xFFFFFFFFFFFFFFFF.

Apply the same guard to client_packet_initialize() so that terminal packets have the same stream_instance_id value as real packets for PER_CHANNEL clients.

Without this fix, babeltrace2 rejects any trace that contains both a real packet and a terminal packet from a PER_CHANNEL channel:
  "Two contiguous packets belong to different data streams:
   expected-data-stream-id=18446744073709551615, data-stream-id=0"

Note: cpu_id in client_packet_initialize() already has the correct guard, only stream_instance_id was missing it.